### PR TITLE
Add missing ruby-devel in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER william@blackhats.net.au
 EXPOSE 4000
 
 RUN zypper in -y python2-Pygments gcc gcc-c++ libxml2-devel libxslt-devel \
-    ruby2.6-rubygem-bundler git make tar gzip && \
+    ruby2.6-rubygem-bundler git make tar gzip ruby-devel && \
     zypper clean
 
 RUN mkdir -p /root/389wiki


### PR DESCRIPTION
`bundle install` failed when installing dependencies (eventlistener in
this case). Installing ruby-devel fixes the issue.